### PR TITLE
chore: Fix routing rewrite tutorial

### DIFF
--- a/docs/tutorial-routing-rewrite.md
+++ b/docs/tutorial-routing-rewrite.md
@@ -108,14 +108,16 @@ import type { RequestHandler } from "@builder.io/qwik-city";
 import { config } from '../speak-config';
 import { rewriteRoutes } from '../speak-routes';
 
-export const onRequest: RequestHandler = ({ params, locale }) => {
-    const parts = url.pathname.split('/')
-    const prefix = url.pathname.startsWith('/') ? parts[1] : parts[0]
-    
-    const lang = rewriteRoutes.find(rewrite => rewrite.prefix === prefix)?.prefix
+export const onRequest: RequestHandler = ({ url, locale }) => {
+  const parts = url.pathname.split('/')
+  const prefix = url.pathname.startsWith('/') ? parts[1] : parts[0]
 
-    // Set Qwik locale
-    locale(lang || config.defaultLocale.lang);
+  const lang = rewriteRoutes.find(
+    rewrite => rewrite.prefix === prefix
+  )?.prefix
+
+  // Set Qwik locale
+  locale(lang || config.defaultLocale.lang);
 };
 ```
 We assign the value of the `lang` parameter (from the url prefix) to Qwik `locale`. This way it will be immediately available to the library.


### PR DESCRIPTION
`url` doesn't exist in this context. Updated to correct field.