### PR TITLE
Update quick-start.md to avoid serialization error

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -56,17 +56,16 @@ import { server$ } from '@builder.io/qwik-city';
 import type { LoadTranslationFn, Translation, TranslationFn } from 'qwik-speak';
 
 /**
- * Translation files are lazy-loaded via dynamic import and will be split into separate chunks during build.
- * Assets names and keys must be valid variable names
- */
-const translationData = import.meta.glob<Translation>('/i18n/**/*.json');
-
-/**
  * Using server$, translation data is always accessed on the server
  */
-const loadTranslation$: LoadTranslationFn = server$(async (lang: string, asset: string) =>
-  await translationData[`/i18n/${lang}/${asset}.json`]?.()
-);
+const loadTranslation$: LoadTranslationFn = server$(async (lang: string, asset: string) => {
+  /**
+   * Translation files are lazy-loaded via dynamic import and will be split into separate chunks during build.
+   * Assets names and keys must be valid variable names
+   */
+  const translationData = import.meta.glob<Translation>('/i18n/**/*.json');
+  return await translationData[`/i18n/${lang}/${asset}.json`]?.()
+});
 
 export const translationFn: TranslationFn = {
   loadTranslation$: loadTranslation$


### PR DESCRIPTION
In recent Qwik version (1.3.1) proposed change is working, previous one throws error, that translationData cannot be serialized.