### PR TITLE
chore(plugin): Logging regarding missing values

### DIFF
--- a/packages/qwik-speak/tools/inline/plugin.ts
+++ b/packages/qwik-speak/tools/inline/plugin.ts
@@ -230,8 +230,12 @@ export function qwikSpeakInline(options: QwikSpeakInlineOptions): Plugin {
 
         log.write(`${target}: ` + (input ?? '-') + '\n');
 
-        log.write('\nMissing value for keys:\n');
-        missingValues.forEach(x => log.write(x + '\n'));
+        if(missingValues.length > 0) {
+          log.write("\nNo keys for 'runtimeAssets' necessary.\n");
+        } else { 
+          log.write('\nMissing value for keys:\n');
+          missingValues.forEach(x => log.write(x + '\n'));
+        }
 
         log.write("\nMake sure the keys are in 'runtimeAssets':\n");
         dynamics.forEach(x => log.write(x + '\n'));

--- a/packages/qwik-speak/tools/inline/plugin.ts
+++ b/packages/qwik-speak/tools/inline/plugin.ts
@@ -230,15 +230,15 @@ export function qwikSpeakInline(options: QwikSpeakInlineOptions): Plugin {
 
         log.write(`${target}: ` + (input ?? '-') + '\n');
 
-        if(missingValues.length > 0) {
-          log.write("\nNo keys for 'runtimeAssets' necessary.\n");
-        } else { 
+        if (missingValues.length > 0) {
           log.write('\nMissing value for keys:\n');
           missingValues.forEach(x => log.write(x + '\n'));
         }
 
-        log.write("\nMake sure the keys are in 'runtimeAssets':\n");
-        dynamics.forEach(x => log.write(x + '\n'));
+        if (dynamics.length > 0) {
+          log.write("\nMake sure the keys are in 'runtimeAssets':\n");
+          dynamics.forEach(x => log.write(x + '\n'));
+        }
 
         log.write((`\nQwik Speak Inline: build ends at ${new Date().toLocaleString()}\n`));
 


### PR DESCRIPTION
To avoid printing `"Make sure the keys are in 'runtimeAssets':` when there are no missing values.

Before:

```bash
client: root.tsx

Missing value for keys:

Make sure the keys are in 'runtimeAssets':

Qwik Speak Inline: build ends at 07/01/2024, 02:22:16

```

After: 
```bash
client: root.tsx

Missing value for keys:

No keys for 'runtimeAssets' necessary.

Qwik Speak Inline: build ends at 07/01/2024, 02:22:16

```
