### PR TITLE
Debug messages in config

### DIFF
--- a/packages/qwik-speak/src/log.ts
+++ b/packages/qwik-speak/src/log.ts
@@ -2,6 +2,18 @@ export const logWarn = (message: string) => {
   console.warn('\x1b[33mQwik Speak warn\x1b[0m %s', message);
 };
 
-export const logDebug = (message: string) => {
-  console.debug('\x1b[36mQwik Speak\x1b[0m %s', message);
+export const logDebug = (enabled: boolean | undefined, message: string) => {
+  if (enabled) {
+    console.debug('\x1b[36mQwik Speak\x1b[0m %s', message);
+  }
+};
+
+export const logDebugInline = (enabled: boolean | undefined, ...message: any) => {
+  if (enabled) {
+    console.debug(
+      '%cQwik Speak Inline',
+      'background: #0c75d2; color: white; padding: 2px 3px; border-radius: 2px; font-size: 0.8em;',
+      ...message
+    );
+  }
 };

--- a/packages/qwik-speak/src/log.ts
+++ b/packages/qwik-speak/src/log.ts
@@ -8,12 +8,12 @@ export const logDebug = (enabled: boolean | undefined, message: string) => {
   }
 };
 
-export const logDebugInline = (enabled: boolean | undefined, ...message: any) => {
+export const logDebugInline = (enabled: boolean | undefined, ...data: any) => {
   if (enabled) {
     console.debug(
       '%cQwik Speak Inline',
       'background: #0c75d2; color: white; padding: 2px 3px; border-radius: 2px; font-size: 0.8em;',
-      ...message
+      ...data
     );
   }
 };

--- a/packages/qwik-speak/src/types.ts
+++ b/packages/qwik-speak/src/types.ts
@@ -122,6 +122,10 @@ export interface SpeakConfig {
    * Domain-based routing options
    */
   domainBasedRouting?: DomainBasedRoutingOption
+  /**
+   * Whether to enable local debugging mode. Default is true
+   */
+  showDebugMessagesLocally?: boolean;
 }
 
 export interface SpeakState {

--- a/packages/qwik-speak/src/use-qwik-speak.tsx
+++ b/packages/qwik-speak/src/use-qwik-speak.tsx
@@ -4,7 +4,7 @@ import { isDev, isServer } from '@builder.io/qwik/build';
 import type { SpeakConfig, SpeakLocale, SpeakState, TranslationFn } from './types';
 import { getSpeakContext, setGetLangFn, setSpeakClientContext, setSpeakServerContext, SpeakContext } from './context';
 import { loadTranslations } from './core';
-import { logDebug, logWarn } from './log';
+import { logDebug, logDebugInline, logWarn } from './log';
 
 export interface QwikSpeakProps {
   /**
@@ -63,8 +63,8 @@ export const useQwikSpeak = (props: QwikSpeakProps) => {
     resolvedLocale = props.config.defaultLocale;
 
     if (isDev) logWarn(`Locale not resolved. Fallback to default locale: ${props.config.defaultLocale.lang}`);
-  } else if (isDev && resolvedConfig.showDebugMessagesLocally) {
-    logDebug(`Resolved locale: ${resolvedLocale.lang}`);
+  } else if (isDev) {
+    logDebug(resolvedConfig.showDebugMessagesLocally, `Resolved locale: ${resolvedLocale.lang}`);
   }
   if (props.currency) resolvedLocale.currency = props.currency;
   if (props.timeZone) resolvedLocale.timeZone = props.timeZone;
@@ -82,7 +82,7 @@ export const useQwikSpeak = (props: QwikSpeakProps) => {
     translationFn: resolvedTranslationFn
   };
 
-  const { config } = state;
+  const {config} = state;
 
   // Set Qwik Speak server context
   setSpeakServerContext(config);
@@ -109,23 +109,14 @@ export const useQwikSpeak = (props: QwikSpeakProps) => {
     // Set the getLang function to use the current lang
     setGetLangFn(() => locale.lang);
 
-    if (isDev && resolvedConfig.showDebugMessagesLocally) {
+    if (isDev) {
       const _speakContext = getSpeakContext();
-      console.debug(
-        '%cQwik Speak Inline',
-        'background: #0c75d2; color: white; padding: 2px 3px; border-radius: 2px; font-size: 0.8em;',
-        'Client context',
-        _speakContext
-      );
+      logDebugInline(resolvedConfig.showDebugMessagesLocally, 'Client context', _speakContext)
     }
 
     // In dev mode, send lang from client to the server
-    if (isDev && resolvedConfig.showDebugMessagesLocally) {
-      console.debug(
-        '%cQwik Speak Inline',
-        'background: #0c75d2; color: white; padding: 2px 3px; border-radius: 2px; font-size: 0.8em;',
-        'Ready'
-      );
+    if (isDev) {
+      logDebugInline(resolvedConfig.showDebugMessagesLocally, 'Ready')
       if (import.meta.hot) {
         import.meta.hot.send('qwik-speak:lang', { msg: locale.lang });
       }

--- a/packages/qwik-speak/src/use-qwik-speak.tsx
+++ b/packages/qwik-speak/src/use-qwik-speak.tsx
@@ -44,18 +44,6 @@ export const useQwikSpeak = (props: QwikSpeakProps) => {
   // Get Qwik locale
   const lang = getLocale('');
 
-  // Resolve locale
-  let resolvedLocale = props.config.supportedLocales.find(value => value.lang === lang);
-  if (!resolvedLocale) {
-    resolvedLocale = props.config.defaultLocale;
-
-    if (isDev) logWarn(`Locale not resolved. Fallback to default locale: ${props.config.defaultLocale.lang}`);
-  } else if (isDev) {
-    logDebug(`Resolved locale: ${resolvedLocale.lang}`);
-  }
-  if (props.currency) resolvedLocale.currency = props.currency;
-  if (props.timeZone) resolvedLocale.timeZone = props.timeZone;
-
   // Resolve config
   const resolvedConfig: SpeakConfig = {
     rewriteRoutes: props.config.rewriteRoutes,
@@ -65,8 +53,21 @@ export const useQwikSpeak = (props: QwikSpeakProps) => {
     runtimeAssets: props.config.runtimeAssets,
     keySeparator: props.config.keySeparator || '.',
     keyValueSeparator: props.config.keyValueSeparator || '@@',
-    domainBasedRouting: props.config.domainBasedRouting
+    domainBasedRouting: props.config.domainBasedRouting,
+    showDebugMessagesLocally: props.config.showDebugMessagesLocally ?? true
   };
+
+  // Resolve locale
+  let resolvedLocale = props.config.supportedLocales.find(value => value.lang === lang);
+  if (!resolvedLocale) {
+    resolvedLocale = props.config.defaultLocale;
+
+    if (isDev) logWarn(`Locale not resolved. Fallback to default locale: ${props.config.defaultLocale.lang}`);
+  } else if (isDev && props.config.showDebugMessagesLocally) {
+    logDebug(`Resolved locale: ${resolvedLocale.lang}`);
+  }
+  if (props.currency) resolvedLocale.currency = props.currency;
+  if (props.timeZone) resolvedLocale.timeZone = props.timeZone;
 
   // Resolve functions
   const resolvedTranslationFn: TranslationFn = {
@@ -108,7 +109,7 @@ export const useQwikSpeak = (props: QwikSpeakProps) => {
     // Set the getLang function to use the current lang
     setGetLangFn(() => locale.lang);
 
-    if (isDev) {
+    if (isDev && props.config.showDebugMessagesLocally) {
       const _speakContext = getSpeakContext();
       console.debug(
         '%cQwik Speak Inline',
@@ -119,7 +120,7 @@ export const useQwikSpeak = (props: QwikSpeakProps) => {
     }
 
     // In dev mode, send lang from client to the server
-    if (isDev) {
+    if (isDev && props.config.showDebugMessagesLocally) {
       console.debug(
         '%cQwik Speak Inline',
         'background: #0c75d2; color: white; padding: 2px 3px; border-radius: 2px; font-size: 0.8em;',

--- a/packages/qwik-speak/src/use-qwik-speak.tsx
+++ b/packages/qwik-speak/src/use-qwik-speak.tsx
@@ -63,7 +63,7 @@ export const useQwikSpeak = (props: QwikSpeakProps) => {
     resolvedLocale = props.config.defaultLocale;
 
     if (isDev) logWarn(`Locale not resolved. Fallback to default locale: ${props.config.defaultLocale.lang}`);
-  } else if (isDev && props.config.showDebugMessagesLocally) {
+  } else if (isDev && resolvedConfig.showDebugMessagesLocally) {
     logDebug(`Resolved locale: ${resolvedLocale.lang}`);
   }
   if (props.currency) resolvedLocale.currency = props.currency;
@@ -109,7 +109,7 @@ export const useQwikSpeak = (props: QwikSpeakProps) => {
     // Set the getLang function to use the current lang
     setGetLangFn(() => locale.lang);
 
-    if (isDev && props.config.showDebugMessagesLocally) {
+    if (isDev && resolvedConfig.showDebugMessagesLocally) {
       const _speakContext = getSpeakContext();
       console.debug(
         '%cQwik Speak Inline',
@@ -120,7 +120,7 @@ export const useQwikSpeak = (props: QwikSpeakProps) => {
     }
 
     // In dev mode, send lang from client to the server
-    if (isDev && props.config.showDebugMessagesLocally) {
+    if (isDev && resolvedConfig.showDebugMessagesLocally) {
       console.debug(
         '%cQwik Speak Inline',
         'background: #0c75d2; color: white; padding: 2px 3px; border-radius: 2px; font-size: 0.8em;',

--- a/packages/qwik-speak/src/use-qwik-speak.tsx
+++ b/packages/qwik-speak/src/use-qwik-speak.tsx
@@ -82,7 +82,7 @@ export const useQwikSpeak = (props: QwikSpeakProps) => {
     translationFn: resolvedTranslationFn
   };
 
-  const {config} = state;
+  const { config } = state;
 
   // Set Qwik Speak server context
   setSpeakServerContext(config);

--- a/packages/qwik-speak/src/use-speak.ts
+++ b/packages/qwik-speak/src/use-speak.ts
@@ -4,7 +4,7 @@ import { isBrowser, isDev } from '@builder.io/qwik/build';
 import { useSpeakContext } from './use-functions';
 import { loadTranslations } from './core';
 import { getSpeakContext } from './context';
-import { logWarn } from './log';
+import { logDebugInline, logWarn } from './log';
 
 export interface SpeakProps {
   /**
@@ -48,12 +48,7 @@ export const useSpeak = (props: SpeakProps) => {
 
     if (isDev && isBrowser) {
       const _speakContext = getSpeakContext();
-      console.debug(
-        '%cQwik Speak Inline',
-        'background: #0c75d2; color: white; padding: 2px 3px; border-radius: 2px; font-size: 0.8em;',
-        'Client context',
-        _speakContext
-      );
+      logDebugInline(config.showDebugMessagesLocally,  'Client context', _speakContext)
     }
   });
 };


### PR DESCRIPTION
Hi,

Currently there's no way to turn off debug messages on local machine. It's very convenient to have them during debugging, but when everything is set up, there's no point to have them in console both on server and client.

This is non-breaking change that adds ability to turn them off. 

If it's not a good fit for your vision, could you add ability to turn them off the way you see it?