### PR TITLE
Fix inlinePlural() handling when Speak context is uninitialized

### DIFF
--- a/packages/qwik-speak/src/inline-plural.ts
+++ b/packages/qwik-speak/src/inline-plural.ts
@@ -6,7 +6,7 @@ export type InlinePluralFn = {
    * Get the plural by a number.
    * The value is passed as a parameter to the translate function
    * @param value A number or a string
-   * @param key Optional key   
+   * @param key Optional key
    * @param params Optional parameters contained in the values
    * @param options Intl PluralRulesOptions object
    * @param lang Optional language if different from the current one
@@ -48,10 +48,10 @@ export const inlinePlural = (): InlinePluralFn => {
       }
     }
 
-    key = key ? `${key}${config.keySeparator}${rule}` : rule;
+    key = key ? `${key}${config.keySeparator || '.'}${rule}` : rule;
 
     const defaultValue = defaultValues ? JSON.parse(defaultValues)[rule] : undefined;
-    if (defaultValue) key = `${key}${config.keyValueSeparator}${defaultValue}`;
+    if (defaultValue) key = `${key}${config.keyValueSeparator || '@@'}${defaultValue}`;
 
     return getValue(key, translation[lang], { value, ...params }, config.keySeparator, config.keyValueSeparator);
   };


### PR DESCRIPTION
Hi,
I discovered an issue where, if the inlinePlural() function was called before the Speak context was properly initialized, the computed values were incorrect because the separators (keySeparator, keyValueSeparator) were undefined. In other parts of the code—such as other functions or during context creation—these separators are replaced with default values, but not here